### PR TITLE
fix: using state variable _tableName to assign value to input element

### DIFF
--- a/client/pages/playground.js
+++ b/client/pages/playground.js
@@ -517,7 +517,7 @@ const QueryModel = ({modelId, tableName, setStep}) => {
             <input
             type="text"
             placeholder="Table name"
-            value={tableName}
+            value={_tableName}
             onChange={(e) => setTableName(e.target.value)}
             className="flex-1 bg-white border border-slate-200 rounded-md shadow-sm px-3 py-1.5 text-sm font-medium text-slate-900 mb-2 w-full" />
           </div>


### PR DESCRIPTION
In Playground, Step 5:

Couldn't write table name, It was updating the actual value, but wasn't visible in input element.

![telegram-cloud-photo-size-5-6244669259548572676-y](https://github.com/OrbisWeb3/orbisdb/assets/20764957/4a7e423d-f0d2-44d1-9368-e8ed48ebc2b3)
