### PR TITLE
Fixing serialization of admin session during setup

### DIFF
--- a/client/components/ConfigurationSettings.js
+++ b/client/components/ConfigurationSettings.js
@@ -208,11 +208,11 @@ export function ConfigurationSetup({showPresets}) {
 
     try {
       const result = await adminOrbisDB.connectUser({ auth, saveSession: false });
-      localStorage.setItem("orbisdb-admin-session", result.session.session);
+      localStorage.setItem("orbisdb-admin-session", result.auth.session.serialize());
       if (result?.user) {
         setAdminAccount(result.user.did);
         setIsAdmin(true);
-        setSessionJwt(result.session.session);
+        setSessionJwt(result.auth.session.serialize());
       }
       setStatusConnect(STATUS.SUCCESS);
     } catch(e) {


### PR DESCRIPTION
Accesses session off of the `auth` child object within result after running `adminOrbisDB.connectUser`, then uses serialization method prior to setting in localStorage and altering state variable.